### PR TITLE
fix(modality): support additional modalities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/sol-scheduling",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packageManager": "yarn@4.4.0",
   "repository": {
     "type": "git",

--- a/src/atoms/BookingError/BookingError.stories.tsx
+++ b/src/atoms/BookingError/BookingError.stories.tsx
@@ -34,7 +34,7 @@ export const BookingError: Story = {
     },
     provider: mockProviderResponse.data,
     otherBookingData: {
-      mode: 'Virtual'
+      mode: 'Telehealth'
     }
   }
 };

--- a/src/atoms/Calendar/week/WeekCalendar.spec.ts
+++ b/src/atoms/Calendar/week/WeekCalendar.spec.ts
@@ -7,7 +7,7 @@ export const NoAvailabilitiesSpec = async ({
 }) => {
   const canvas = within(canvasElement);
   const virtualButton = await canvas.findByRole('button', {
-    name: 'Virtual'
+    name: 'Telehealth'
   });
   await userEvent.click(virtualButton);
   const mondayCard = await canvas.findByTestId('Mon Jan 01 2024');

--- a/src/atoms/ProviderSelection/ProviderSelection.spec.ts
+++ b/src/atoms/ProviderSelection/ProviderSelection.spec.ts
@@ -32,7 +32,7 @@ export const ProviderSelectionSpec = async ({
     autoClose?: boolean;
   }) => {
     const buttonText = button.innerText;
-    await expect(button).toHaveClass('bg-slate-300');
+    await expect(button).toHaveClass('border-slate-200');
     await userEvent.click(button);
     const closeButton = await canvas.findByLabelText('Close filter');
     await expect(closeButton).toBeVisible();
@@ -42,16 +42,17 @@ export const ProviderSelectionSpec = async ({
     await expect(filterButton).toHaveTextContent(filterName);
     await userEvent.click(filterButton);
     if (!autoClose) {
-      await expect(filterButton).toHaveClass('bg-primary');
+      await expect(filterButton).toHaveClass('ring-secondary');
       await userEvent.click(closeButton);
     }
     await expect(filterButton).not.toBeVisible();
-    await expect(button).toHaveClass('bg-secondary');
+    await expect(button).toHaveClass('ring-secondary');
+    await expect(button).toHaveClass('text-primary');
     const clearFilter = await canvas.findByLabelText(
       `Clear ${buttonText} filter`
     );
     await userEvent.click(clearFilter);
-    await expect(button).toHaveClass('bg-slate-300');
+    await expect(button).toHaveClass('border-slate-200');
   };
   await testApplyFilter({
     button: ethnicityButton,
@@ -75,7 +76,7 @@ export const ProviderSelectionSpec = async ({
   });
   await testApplyFilter({
     button: locationButton,
-    filterName: 'NY - Union Square',
+    filterName: 'Union Square',
     autoClose: true
   });
 };

--- a/src/lib/api/schema/atoms/TherapeuticModality.schema.ts
+++ b/src/lib/api/schema/atoms/TherapeuticModality.schema.ts
@@ -2,7 +2,17 @@ import { z } from 'zod';
 
 export enum Modality {
   'Psychiatric' = 'Psychiatric',
-  'Therapy' = 'Therapy'
+  'Therapy' = 'Therapy',
+  'Both' = 'Both',
+  'Not sure' = 'Not sure'
 }
 
-export const TherapeuticModalitySchema = z.nativeEnum(Modality);
+export const TherapeuticModalitySchema = z
+  .nativeEnum(Modality)
+  .transform((value) => {
+    if (value === Modality.Therapy) {
+      return 'Therapy';
+    } else {
+      return 'Psychiatric';
+    }
+  });

--- a/src/molecules/Scheduler/Scheduler.spec.ts
+++ b/src/molecules/Scheduler/Scheduler.spec.ts
@@ -15,13 +15,13 @@ export const SchedulerSpec = async ({
 
   /** Get all elements of interests */
   const cherryCreekButton = await canvas.findByRole('button', {
-    name: 'CO - Cherry Creek'
+    name: 'Cherry Creek'
   });
   const unionSquareButton = await canvas.findByRole('button', {
-    name: 'NY - Union Square'
+    name: 'Union Square'
   });
   const virtualButton = await canvas.findByRole('button', {
-    name: 'Virtual'
+    name: 'Telehealth'
   });
   const prevWeekButton = await canvas.findByLabelText('Go to previous week');
   const nextWeekButton = await canvas.findByLabelText('Go to next week');


### PR DESCRIPTION
### **User description**
the 'Both' and 'Not sure' modalities should be acceptable inputs, but should map to 'Psychiatric', so the API back and forth between sol and the betsol api shouldn't change


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added support for 'Both' and 'Not sure' modalities in the `Modality` enum.
- Implemented a transformation to map 'Both' and 'Not sure' to 'Psychiatric', ensuring compatibility with existing API expectations.
- Updated package version to 0.3.1 to reflect changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TherapeuticModality.schema.ts</strong><dd><code>Support additional modalities and map them correctly</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/api/schema/atoms/TherapeuticModality.schema.ts

<li>Added 'Both' and 'Not sure' to the <code>Modality</code> enum.<br> <li> Implemented a transformation to map 'Both' and 'Not sure' to <br>'Psychiatric'.<br> <li> Ensured 'Therapy' remains unchanged in transformation.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/43/files#diff-aa0599e2ff8cf40106f82d4d35066f8aa7604cb39b04195ccd13179b93e32af6">+12/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump package version to 0.3.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Updated version from 0.3.0 to 0.3.1.



</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/43/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information