### PR TITLE
allow user to re-render providers if error dissappears

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/sol-scheduling",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "packageManager": "yarn@4.4.0",
   "repository": {
     "type": "git",

--- a/src/SolApiProvider/SolApiContext.tsx
+++ b/src/SolApiProvider/SolApiContext.tsx
@@ -114,6 +114,7 @@ export const SolApiProvider: FC<ContextProps> = ({
   const getProviders = useCallback(
     async (prefs: GetProvidersInputType) => {
       setLoadingProviders(true);
+      setProvidersError(null);
       try {
         const res = await fetchProviders(prefs);
         setProviders(res.data);


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Reset the provider error state before fetching providers to allow re-rendering when errors disappear.
- Updated the package version from 0.3.4 to 0.3.5 to reflect changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SolApiContext.tsx</strong><dd><code>Reset provider error state before fetching providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SolApiProvider/SolApiContext.tsx

<li>Added logic to reset provider error state before fetching providers.<br> <li> Ensures that the error state is cleared when attempting to re-fetch <br>providers.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/47/files#diff-9a9a6eac4b7962815c3aa603baa1a149516e3e1a415dc5ac6db6a71bfaca4495">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump package version to 0.3.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Updated package version from 0.3.4 to 0.3.5.



</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/47/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information