### PR TITLE
Support retrieving a provider by Wordpress ID

### DIFF
--- a/docs/api.spec.yaml
+++ b/docs/api.spec.yaml
@@ -67,6 +67,7 @@ paths:
                         id:
                           type: string
                           format: number
+                          description: The resource ID of the provider
                           example:
                             $ref: '#/components/examples/ProviderId/value'
                         name:
@@ -112,11 +113,21 @@ paths:
   /api/provider/info:
     get:
       summary: Get a single provider
+      description: Retrieves a single provider by either `providerId` or `wordpressId`. Only one of the two parameters should be provided.
       security:
         - bearerAuth: []
       parameters:
         - in: query
           name: providerId
+          description: The resource ID of the provider
+          example: 1637
+          schema:
+            type: string
+            format: number
+        - in: query
+          name: wordpressId
+          description: The ID of the provider in WordPress
+          example: 9104
           schema:
             type: string
             format: number
@@ -131,6 +142,11 @@ paths:
                   data:
                     type: object
                     properties:
+                      id:
+                        type: string
+                        description: The resource ID of the provider
+                        example:
+                          $ref: '#/components/examples/ProviderId/value'
                       location:
                         type: object
                         properties:
@@ -168,6 +184,7 @@ paths:
               properties:
                 providerId:
                   type: array
+                  description: The resource ID of the provider
                   items:
                     type: string
                     format: number
@@ -186,6 +203,7 @@ paths:
                     properties:
                       providerId:
                         type: array
+                        description: The resource ID of the provider
                         items:
                           allOf:
                             - $ref: '#/components/schemas/Event'
@@ -220,6 +238,7 @@ paths:
                     $ref: '#/components/examples/EventId/value'
                 providerId:
                   type: string
+                  description: The resource ID of the provider
                   format: number
                   example:
                     $ref: '#/components/examples/ProviderId/value'
@@ -462,6 +481,7 @@ components:
             $ref: '#/components/examples/EventDate/value'
         providerId:
           type: string
+          description: The resource ID of the provider
           format: number
           example:
             $ref: '#/components/examples/ProviderId/value'
@@ -509,6 +529,8 @@ components:
       value: 'd1v656q25g7q3dvgu8as18uhvo'
     ProviderId:
       value: '1637'
+    WordpressId:
+      value: '9104'
     ProviderName:
       value: 'John Doe'
     EventSlotStart:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/sol-scheduling",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "packageManager": "yarn@4.4.0",
   "repository": {
     "type": "git",

--- a/src/lib/api/__mocks__/GetProvider.mock.ts
+++ b/src/lib/api/__mocks__/GetProvider.mock.ts
@@ -6,6 +6,7 @@ export const getMockProviderResponse = () => {
    */
   const res = GetProviderResponseSchema.safeParse({
     data: {
+      id: '1820',
       location: {
         facility: '',
         state: 'NY - Brooklyn Heights'

--- a/src/lib/api/schema/GetProvider.schema.ts
+++ b/src/lib/api/schema/GetProvider.schema.ts
@@ -3,6 +3,7 @@ import { errorSchema } from './shared.schema';
 
 export const GetProviderInputSchema = z.object({
   providerId: z.string().min(1)
+  // wordpressId - I'm not including wordpressId here as we can assume the Scheduling experience always works with the resource ID
 });
 
 export type GetProviderInputType = z.infer<typeof GetProviderInputSchema>;
@@ -14,6 +15,7 @@ export type GetProviderInputType = z.infer<typeof GetProviderInputSchema>;
 export const GetProviderResponseSchema = z
   .object({
     data: z.object({
+      id: z.string(), // Resource ID of the provider
       location: z
         .object({
           facility: z.string().optional(),


### PR DESCRIPTION
### Overview of changes

- GET `api/provider/info` adds support for a new query parameter that allows retrieving a provider based on the Wordpress ID
- In the response of GET `api/provider/info` the `id` of the provider is returned (which is the `resourceId`)

<img width="806" alt="Screenshot 2024-10-31 at 10 22 51" src="https://github.com/user-attachments/assets/24ee8926-2487-45a0-abc5-c4da26710f44">

___

### **Description**
- Enhanced the API documentation to support retrieving a provider by `wordpressId` in addition to `providerId`.
- Added detailed descriptions for the `providerId` and `wordpressId` parameters in the `/api/provider/info` endpoint.
- Included example values for `wordpressId` to improve clarity and usability.
- Updated various sections of the API specification to include descriptions for provider-related fields.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.spec.yaml</strong><dd><code>Enhance API documentation to support provider retrieval by WordPress </code><br><code>ID</code></dd></summary>
<hr>

docs/api.spec.yaml

<li>Added descriptions for <code>providerId</code> and <code>wordpressId</code> parameters.<br> <li> Updated API endpoint to support retrieval by <code>wordpressId</code>.<br> <li> Included example values for <code>wordpressId</code>.<br> <li> Enhanced documentation with detailed descriptions for provider-related <br>fields.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/59/files#diff-54257850d1e5f919370feac28187bc5bfea7ba106ce4a5037640a2d56a530ede">+22/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information