### PR TITLE
feat(): autofocus on week with availability

### DIFF
--- a/src/atoms/Calendar/week/WeekCalendar.spec.ts
+++ b/src/atoms/Calendar/week/WeekCalendar.spec.ts
@@ -55,3 +55,27 @@ export const NoAvailabilitiesSpec = async ({
     'nextWeekButton should be disabled after 5 weeks in advance'
   ).toBeDisabled();
 };
+
+export const CurrentWeekAvailabilitySpec = async ({
+  canvasElement
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  const canvas = within(canvasElement);
+  expect(
+    await canvas.findByTestId('Mon Oct 14 2024'),
+    'Oct 14 2024 should be visible'
+  ).toBeVisible();
+};
+
+export const NextWeekAvailabilitySpec = async ({
+  canvasElement
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  const canvas = within(canvasElement);
+  expect(
+    await canvas.findByTestId('Mon Oct 21 2024'),
+    'Oct 21 2024 should be visible'
+  ).toBeVisible();
+};

--- a/src/atoms/Calendar/week/WeekCalendar.spec.ts
+++ b/src/atoms/Calendar/week/WeekCalendar.spec.ts
@@ -1,11 +1,22 @@
 import { within, userEvent, expect } from '@storybook/test';
 
+/**
+ * For all tests below, the current date is mocked to be 2024-10-14
+ */
+
 export const NoAvailabilitiesSpec = async ({
   canvasElement
 }: {
   canvasElement: HTMLElement;
 }) => {
   const canvas = within(canvasElement);
+
+  // Current week should be visible
+  expect(
+    await canvas.findByTestId('Mon Oct 14 2024'),
+    'Oct 14 2024 should be visible'
+  ).toBeVisible();
+
   const virtualButton = await canvas.findByRole('button', {
     name: 'Telehealth'
   });
@@ -62,6 +73,8 @@ export const CurrentWeekAvailabilitySpec = async ({
   canvasElement: HTMLElement;
 }) => {
   const canvas = within(canvasElement);
+
+  // Current week should be visible
   expect(
     await canvas.findByTestId('Mon Oct 14 2024'),
     'Oct 14 2024 should be visible'
@@ -74,6 +87,8 @@ export const NextWeekAvailabilitySpec = async ({
   canvasElement: HTMLElement;
 }) => {
   const canvas = within(canvasElement);
+
+  // Next week should be visible
   expect(
     await canvas.findByTestId('Mon Oct 21 2024'),
     'Oct 21 2024 should be visible'

--- a/src/atoms/Calendar/week/WeekCalendar.stories.tsx
+++ b/src/atoms/Calendar/week/WeekCalendar.stories.tsx
@@ -3,7 +3,12 @@ import { WeekCalendar as WeekCalendarComponent } from './WeekCalendar';
 import { ThemeProvider } from '@awell-health/ui-library';
 import { fn } from '@storybook/test';
 import { mockProviderAvailabilityResponse } from '@/lib/api/__mocks__';
-import { NoAvailabilitiesSpec } from './WeekCalendar.spec';
+import {
+  NoAvailabilitiesSpec,
+  NextWeekAvailabilitySpec,
+  CurrentWeekAvailabilitySpec
+} from './WeekCalendar.spec';
+import { EventDeliveryMethod } from '@/lib/api';
 
 const meta: Meta<typeof WeekCalendarComponent> = {
   title: 'Atoms/Calendar/Week',
@@ -63,5 +68,67 @@ export const TestNoAvailabilities: Story = {
       hideWeekends: true
     };
     return <WeekCalendarComponent {...noAvailArgs} />;
+  }
+};
+
+export const TestCurrentWeekAvailability: Story = {
+  play: CurrentWeekAvailabilitySpec,
+  render: (args) => {
+    // Current date is mocked to be 2024-10-14 (Monday)
+    const scrollToAvailabilitiesArgs = {
+      ...args,
+      availabilities: [
+        {
+          eventId: 't68403en62hji9lad095mv2srk',
+          slotstart: new Date('2024-10-15T21:00:00Z'), // Tuesday, same week
+          providerId: '1717',
+          duration: 60,
+          facility: 'NY - Brooklyn Heights',
+          location: EventDeliveryMethod.Telehealth
+        },
+        {
+          eventId: 't68403en62hji9lad095mv2srk',
+          slotstart: new Date('2024-10-22T21:00:00Z'), // Tuesday, next week
+          providerId: '1717',
+          duration: 60,
+          facility: 'NY - Brooklyn Heights',
+          location: EventDeliveryMethod.Telehealth
+        }
+      ],
+      weekStartsOn: 'monday' as const,
+      hideWeekends: true
+    };
+    return <WeekCalendarComponent {...scrollToAvailabilitiesArgs} />;
+  }
+};
+
+export const TestNextWeekAvailability: Story = {
+  play: NextWeekAvailabilitySpec,
+  render: (args) => {
+    // Current date is mocked to be 2024-10-14 (Monday)
+    const scrollToAvailabilitiesArgs = {
+      ...args,
+      availabilities: [
+        {
+          eventId: 't68403en62hji9lad095mv2srk',
+          slotstart: new Date('2024-10-21T21:00:00Z'), // Monday one week later
+          providerId: '1717',
+          duration: 60,
+          facility: 'NY - Brooklyn Heights',
+          location: EventDeliveryMethod.Telehealth
+        },
+        {
+          eventId: 't68403en62hji9lad095mv2srk',
+          slotstart: new Date('2024-10-28T21:00:00Z'), // Monday two weeks later
+          providerId: '1717',
+          duration: 60,
+          facility: 'NY - Brooklyn Heights',
+          location: EventDeliveryMethod.Telehealth
+        }
+      ],
+      weekStartsOn: 'monday' as const,
+      hideWeekends: true
+    };
+    return <WeekCalendarComponent {...scrollToAvailabilitiesArgs} />;
   }
 };

--- a/src/atoms/Calendar/week/WeekCalendar.tsx
+++ b/src/atoms/Calendar/week/WeekCalendar.tsx
@@ -65,6 +65,23 @@ export const WeekCalendar: FC<WeekCalendarProps> = ({
     handleSelectLocation(preferredLocation);
   }, [availabilities]);
 
+  useEffect(() => {
+    if (availabilities.length > 0) {
+      const firstAvailableSlot = availabilities.reduce((earliest, slot) =>
+        earliest && earliest.slotstart < slot.slotstart ? earliest : slot
+      );
+
+      const firstAvailableWeekStart = startOfWeek(
+        firstAvailableSlot.slotstart,
+        {
+          weekStartsOn: weekStartsOn === 'sunday' ? 0 : 1
+        }
+      );
+
+      setCurrentWeek(firstAvailableWeekStart);
+    }
+  }, [availabilities, weekStartsOn]);
+
   const handlePreviousWeek = useCallback(() => {
     setCurrentWeek((prevWeek) => subWeeks(prevWeek, 1));
   }, []);

--- a/src/molecules/Scheduler/Scheduler.stories.tsx
+++ b/src/molecules/Scheduler/Scheduler.stories.tsx
@@ -18,7 +18,12 @@ const meta: Meta<typeof SchedulerComponent> = {
   title: 'Molecules/Scheduler',
   component: SchedulerComponent,
   parameters: {
-    mockingDate: new Date('2024-10-14T18:00:00.000Z'),
+    /**
+     * We are mocking the current date to be 2024-10-07.
+     * First available appointment is on 2024-10-17 but scheduler
+     * should auto focus on the week with first available date
+     */
+    mockingDate: new Date('2024-10-07T18:00:00.000Z'),
     fetchAvailability: fetchAvailabilityMock
   },
   decorators: [


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Implemented a feature to auto-focus on the week with the first availability in the `WeekCalendar` component.
- Added new test specifications to verify the visibility of current and next week availabilities.
- Updated stories in `WeekCalendar.stories.tsx` to include tests for current and next week availability.
- Modified the scheduler story to mock the current date and demonstrate the auto-focus feature.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WeekCalendar.spec.ts</strong><dd><code>Add tests for week availability visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/atoms/Calendar/week/WeekCalendar.spec.ts

<li>Added test specification for current week availability.<br> <li> Added test specification for next week availability.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/68/files#diff-57252b3859ea2af4ec8e349f23a7a05608a46914a0bdb861c31d84ac2a100c64">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WeekCalendar.stories.tsx</strong><dd><code>Add stories for week availability tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/atoms/Calendar/week/WeekCalendar.stories.tsx

<li>Added story for testing current week availability.<br> <li> Added story for testing next week availability.<br> <li> Imported new test specifications.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/68/files#diff-02e12de2f2c188f7f031b720b706fdb459b64532726c72710e04929a8c827692">+68/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Scheduler.stories.tsx</strong><dd><code>Update scheduler story with new mocking date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/molecules/Scheduler/Scheduler.stories.tsx

<li>Updated mocking date for scheduler story.<br> <li> Added comments explaining the mocking date and focus behavior.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/68/files#diff-26968c56e55ed550f3ed971582fb307857a1383811a758bade6e4757ff7bb7c2">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WeekCalendar.tsx</strong><dd><code>Implement auto-focus on week with first availability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/atoms/Calendar/week/WeekCalendar.tsx

<li>Implemented auto-focus on the week with the first availability.<br> <li> Added useEffect to set the current week based on availability.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/68/files#diff-c8db8f13758f2859f54ec190ed065d65a88ac9f3c236b75cf3faa8ae4deca4da">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information