### PR TITLE
ET-418: hide profile link

### DIFF
--- a/src/atoms/ProviderSelection/ProviderCard.tsx
+++ b/src/atoms/ProviderSelection/ProviderCard.tsx
@@ -25,6 +25,14 @@ export const ProviderCard: FC<ProviderProps> = ({
   const facilities = uniq((provider?.events ?? []).map((e) => e.facility));
   const profileLink = provider.profileLink ?? '';
   const providerName = `${provider.firstName} ${provider.lastName}`;
+
+  /*
+   * Using a variable to hide the profile link instead of removing it:
+   * They want to do some AB testing and might ask to add this back in at a later time
+   * See https://linear.app/awell/issue/ET-418/remove-link-to-bio
+   */
+  const showProfileLink = false;
+
   return (
     <div key={provider.id} className='rounded-md border-1 bg-white p-4'>
       <div className='flex gap-4 align-center justify-between'>
@@ -40,13 +48,17 @@ export const ProviderCard: FC<ProviderProps> = ({
                   {toFullNameState(location)}
                 </span>
               )}
-              {location.length > 0 && profileLink.length > 0 && (
-                <span className='text-slate-600 text-md hidden sm:inline px-1'>
-                  •
-                </span>
-              )}
-              {profileLink.length > 0 && (
-                <LinkToProfileItem link={profileLink} />
+              {showProfileLink && (
+                <>
+                  {location.length > 0 && profileLink.length > 0 && (
+                    <span className='text-slate-600 text-md hidden sm:inline px-1'>
+                      •
+                    </span>
+                  )}
+                  {profileLink.length > 0 && (
+                    <LinkToProfileItem link={profileLink} />
+                  )}
+                </>
               )}
             </div>
           </div>


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a `showProfileLink` variable to control the visibility of the profile link in the `ProviderCard` component.
- Wrapped profile link elements in a conditional block to facilitate potential future AB testing.
- Added comments to explain the rationale behind hiding the profile link.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProviderCard.tsx</strong><dd><code>Add conditional logic to hide profile link for AB testing</code></dd></summary>
<hr>

src/atoms/ProviderSelection/ProviderCard.tsx

<li>Introduced a <code>showProfileLink</code> variable to control the visibility of the <br>profile link.<br> <li> Wrapped profile link related elements in a conditional block based on <br><code>showProfileLink</code>.<br> <li> Added comments explaining the reason for hiding the profile link.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/69/files#diff-1f55c297285c91f160d473923f573064037afd06ffd273a64aca1fcc37264f26">+19/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information