### PR TITLE
ET-420: Weekcalendar - set location based on preference

### DIFF
--- a/src/atoms/Calendar/week/WeekCalendar.spec.ts
+++ b/src/atoms/Calendar/week/WeekCalendar.spec.ts
@@ -4,6 +4,30 @@ import { within, userEvent, expect } from '@storybook/test';
  * For all tests below, the current date is mocked to be 2024-10-14
  */
 
+export const WithAvailabilitiesAndInPersonPreferenceSpec = async ({
+  canvasElement
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  const canvas = within(canvasElement);
+
+  const physicalLocationFilter = await canvas.findByRole('button', {
+    name: 'Brooklyn Heights'
+  });
+
+  expect(physicalLocationFilter).toHaveClass('selected');
+
+  const availableDay = await canvas.findByTestId('Tue Oct 15 2024');
+
+  /**
+   * There is only one In-Person slot available in our test data
+   */
+  expect(
+    await within(availableDay).findByText('1 slot'),
+    `${availableDay.innerText.replace('\n', ' ')} should have 1 slot`
+  ).toBeTruthy();
+};
+
 export const NoAvailabilitiesSpec = async ({
   canvasElement
 }: {
@@ -20,6 +44,8 @@ export const NoAvailabilitiesSpec = async ({
   const virtualButton = await canvas.findByRole('button', {
     name: 'Telehealth'
   });
+  expect(virtualButton).toHaveClass('selected');
+
   await userEvent.click(virtualButton);
   const mondayCard = await canvas.findByTestId('Mon Oct 14 2024');
   const tuesdayCard = await canvas.findByTestId('Tue Oct 15 2024');

--- a/src/atoms/Calendar/week/WeekCalendar.stories.tsx
+++ b/src/atoms/Calendar/week/WeekCalendar.stories.tsx
@@ -6,9 +6,10 @@ import { mockProviderAvailabilityResponse } from '@/lib/api/__mocks__';
 import {
   NoAvailabilitiesSpec,
   NextWeekAvailabilitySpec,
-  CurrentWeekAvailabilitySpec
+  CurrentWeekAvailabilitySpec,
+  WithAvailabilitiesAndInPersonPreferenceSpec
 } from './WeekCalendar.spec';
-import { EventDeliveryMethod } from '@/lib/api';
+import { DeliveryMethod, EventDeliveryMethod } from '@/lib/api';
 
 const meta: Meta<typeof WeekCalendarComponent> = {
   title: 'Atoms/Calendar/Week',
@@ -55,6 +56,37 @@ export const WithAvailabilities: Story = {
     availabilities: mockProviderAvailabilityResponse('1717').data['1717'],
     weekStartsOn: 'monday',
     hideWeekends: true
+  }
+};
+
+export const TestWithAvailabilitiesAndInPersonPreference: Story = {
+  play: WithAvailabilitiesAndInPersonPreferenceSpec,
+  args: {
+    weekStartsOn: 'monday',
+    hideWeekends: true,
+    deliveryMethodPreference: DeliveryMethod.InPerson,
+    /**
+     * Test with two In-Person availabilities on different locations.
+     * Should set location filter to the first availability location.
+     */
+    availabilities: [
+      {
+        eventId: 't68403en62hji9lad095mv2srk',
+        slotstart: new Date('2024-10-15T21:00:00Z'), // Tuesday, same week
+        providerId: '1717',
+        duration: 60,
+        facility: 'NY - Brooklyn Heights',
+        location: EventDeliveryMethod.InPerson
+      },
+      {
+        eventId: 't68403en62hji9lad095mv2srk',
+        slotstart: new Date('2024-10-16T21:00:00Z'), // Wednesday, same week
+        providerId: '1717',
+        duration: 60,
+        facility: 'NY - Long Island City',
+        location: EventDeliveryMethod.InPerson
+      }
+    ]
   }
 };
 

--- a/src/molecules/Scheduler/Scheduler.tsx
+++ b/src/molecules/Scheduler/Scheduler.tsx
@@ -37,7 +37,8 @@ export const Scheduler: FC<SchedulerProps> = ({
 
   const { allowSchedulingInThePast = false } = opts || {};
 
-  const { setSelectedSlot, bookingInformation, setLocation } = usePreferences();
+  const { setSelectedSlot, bookingInformation, setLocation, preferences } =
+    usePreferences();
   const {
     provider: { getId: provivderId }
   } = useSolApi();
@@ -122,6 +123,10 @@ export const Scheduler: FC<SchedulerProps> = ({
     );
   };
 
+  const selectedDeliveryMethodPreferences = useMemo(() => {
+    return preferences.deliveryMethod;
+  }, [preferences]);
+
   if (provivderId === null) {
     return <div>No provider selected.</div>;
   }
@@ -154,6 +159,7 @@ export const Scheduler: FC<SchedulerProps> = ({
           availabilities={availabilities}
           onDateSelect={handleDateSelect}
           onLocationSelect={setLocation}
+          deliveryMethodPreference={selectedDeliveryMethodPreferences}
           allowSchedulingInThePast={allowSchedulingInThePast}
         />
       </div>


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `WeekCalendar` component to support a `deliveryMethodPreference` prop, allowing automatic selection of location based on user preference.
- Updated the `Scheduler` component to utilize the delivery method preference from user settings.
- Added a new test specification to verify the in-person preference functionality in the `WeekCalendar`.
- Introduced a new story in `WeekCalendar.stories.tsx` to demonstrate the in-person preference feature with test data.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WeekCalendar.spec.ts</strong><dd><code>Add test for in-person preference in WeekCalendar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/atoms/Calendar/week/WeekCalendar.spec.ts

<li>Added a new test specification for in-person preference.<br> <li> Verified the selection of physical location filter.<br> <li> Checked the availability of in-person slots.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/71/files#diff-57252b3859ea2af4ec8e349f23a7a05608a46914a0bdb861c31d84ac2a100c64">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WeekCalendar.stories.tsx</strong><dd><code>Add story for in-person preference in WeekCalendar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/atoms/Calendar/week/WeekCalendar.stories.tsx

<li>Introduced a new story for in-person preference.<br> <li> Added delivery method preference to story arguments.<br> <li> Configured test data for in-person availabilities.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/71/files#diff-02e12de2f2c188f7f031b720b706fdb459b64532726c72710e04929a8c827692">+34/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WeekCalendar.tsx</strong><dd><code>Enhance WeekCalendar with delivery method preference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/atoms/Calendar/week/WeekCalendar.tsx

<li>Introduced <code>deliveryMethodPreference</code> prop.<br> <li> Set initial location based on delivery method preference.<br> <li> Updated location selection logic.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/71/files#diff-c8db8f13758f2859f54ec190ed065d65a88ac9f3c236b75cf3faa8ae4deca4da">+41/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Scheduler.tsx</strong><dd><code>Integrate delivery method preference in Scheduler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/molecules/Scheduler/Scheduler.tsx

<li>Integrated delivery method preference into Scheduler.<br> <li> Utilized preferences for setting delivery method.<br>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/71/files#diff-eef262f64e62095fc85b16a89da87d6b6885522f8ff6993695dd5dcd2e815d0b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information