### PR TITLE
REV-477 sol intake bug question

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awell-health/sol-scheduling",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "packageManager": "yarn@4.4.0",
   "repository": {
     "type": "git",

--- a/src/SolApiProvider/SolApiContext.tsx
+++ b/src/SolApiProvider/SolApiContext.tsx
@@ -116,7 +116,19 @@ export const SolApiProvider: FC<ContextProps> = ({
       setLoadingProviders(true);
       setProvidersError(null);
       try {
-        const res = await fetchProviders(prefs);
+        /**
+         * REV-477: default to 30 because if age is not set, the API will return no providers
+         *
+         * We cannot set the default in the GetProviders.schema.ts file because we have been
+         * mixing up input and output types and changing that now is too risky.
+         * Instead, we set the default here.
+         */
+        const DEFAULT_AGE = 30;
+        const res = await fetchProviders({
+          ...prefs,
+          age: prefs.age ?? DEFAULT_AGE.toString()
+        });
+
         setProviders(res.data);
       } catch (e) {
         setProvidersError(e);

--- a/src/lib/api/schema/GetProviders.schema.ts
+++ b/src/lib/api/schema/GetProviders.schema.ts
@@ -19,7 +19,7 @@ const transformEmptyToUndefined = <T extends z.ZodType>(schema: T) =>
   schema.transform((v): z.infer<T> | undefined => (isEmpty(v) ? undefined : v));
 
 export const GetProvidersInputSchema = z.object({
-  age: transformEmptyToUndefined(AgeSchema).default(30), //REV-477: default to 30 because if age is not set, the API will retur no providers
+  age: transformEmptyToUndefined(AgeSchema).optional(),
   gender: transformEmptyToUndefined(GenderSchema).optional(),
   ethnicity: transformEmptyToUndefined(EthnicitySchema).optional(),
   // Not implemented

--- a/src/lib/api/schema/GetProviders.schema.ts
+++ b/src/lib/api/schema/GetProviders.schema.ts
@@ -19,7 +19,7 @@ const transformEmptyToUndefined = <T extends z.ZodType>(schema: T) =>
   schema.transform((v): z.infer<T> | undefined => (isEmpty(v) ? undefined : v));
 
 export const GetProvidersInputSchema = z.object({
-  age: transformEmptyToUndefined(AgeSchema).optional(),
+  age: transformEmptyToUndefined(AgeSchema).default(30), //REV-477: default to 30 because if age is not set, the API will retur no providers
   gender: transformEmptyToUndefined(GenderSchema).optional(),
   ethnicity: transformEmptyToUndefined(EthnicitySchema).optional(),
   // Not implemented


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Default age to 30 in providers query

- Prevent empty age causing no providers

- Update package version to 0.4.3


___

### Diagram Walkthrough


```mermaid
flowchart LR
  input["GetProvidersInputSchema"] -- "default age 30" --> api["Provider search API"]
  api -- "returns providers" --> client["Scheduling client"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GetProviders.schema.ts</strong><dd><code>Default age to 30 in providers input schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/api/schema/GetProviders.schema.ts

<ul><li>Set <code>age</code> to <code>default(30)</code> instead of optional.<br> <li> Add inline comment explaining API returns no providers if age unset.</ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/84/files#diff-971b3a230a8a3ff255ae821bd2db5f4bdee62b300a3e745e6817624d958d7f8b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Version bump to 0.4.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Bump package version from 0.4.2 to 0.4.3.


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/84/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

