### PR TITLE
feat: enforce psychiatry-first booking for patients choosing medicare insurance

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-export PATH="$HOME/.nvm/versions/node/v24.12.0/bin:$PATH"
 pnpm --filter @awell-health/sol-scheduling exec lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+export PATH="$HOME/.nvm/versions/node/v24.12.0/bin:$PATH"
 pnpm --filter @awell-health/sol-scheduling exec lint-staged

--- a/apps/scheduling-app/app/providers/components/ProviderFilters.tsx
+++ b/apps/scheduling-app/app/providers/components/ProviderFilters.tsx
@@ -29,7 +29,7 @@ import {
   TimeOfTheDay,
 } from '../_lib/types';
 import { clearPreferencesStorage } from '../_lib/onboarding';
-import { SERVICE_OPTIONS } from '../../../lib/fields/registry';
+import { SERVICE_OPTIONS, INSURANCE_CARRIER_GROUPS } from '../../../lib/fields/registry';
 import { FilterPill, ActiveFilterTag, type FilterOption } from './filters';
 
 type ProviderFiltersProps = {
@@ -321,6 +321,11 @@ export function ProviderFilters({
             }
             onClose={() => setActiveDesktopFilter(null)}
             isSubmitting={isSubmitting}
+            disabledValues={
+              values.insurance === INSURANCE_CARRIER_GROUPS.MEDICARE
+                ? serviceOptions.map((o) => o.value).filter((v) => v !== Modality.Psychiatric)
+                : undefined
+            }
           />
 
           {/* Delivery */}
@@ -523,7 +528,14 @@ export function ProviderFilters({
                     </SelectTrigger>
                     <SelectContent>
                       {serviceOptions.map((option) => (
-                        <SelectItem key={option.value} value={option.value}>
+                        <SelectItem
+                          key={option.value}
+                          value={option.value}
+                          disabled={
+                            values.insurance === INSURANCE_CARRIER_GROUPS.MEDICARE &&
+                            option.value !== Modality.Psychiatric
+                          }
+                        >
                           {option.label}
                         </SelectItem>
                       ))}

--- a/apps/scheduling-app/app/providers/components/filters/FilterPill.tsx
+++ b/apps/scheduling-app/app/providers/components/filters/FilterPill.tsx
@@ -27,6 +27,8 @@ interface FilterPillProps<T extends string> {
   clearable?: boolean;
   /** Whether apply is in progress */
   isSubmitting?: boolean;
+  /** Values that should be rendered as disabled/greyed-out in the dropdown */
+  disabledValues?: T[];
 }
 
 const basePillClasses =
@@ -48,6 +50,7 @@ export function FilterPill<T extends string>({
   disabled = false,
   clearable = true,
   isSubmitting = false,
+  disabledValues,
 }: FilterPillProps<T>) {
   const dropdownRef = useRef<HTMLDivElement>(null);
   
@@ -112,22 +115,29 @@ export function FilterPill<T extends string>({
       {isOpen && (
         <div className='absolute left-0 z-30 mt-2 w-64 rounded-2xl border border-slate-200 bg-white p-4 shadow-card'>
           <div className='max-h-64 space-y-2 overflow-y-auto text-sm'>
-            {options.map((option) => (
-              <label
-                key={option.value}
-                className='flex items-center gap-2 text-slate-700'
-              >
-                <input
-                  type='radio'
-                  name={filterKey}
-                  value={option.value}
-                  checked={draftValue === option.value}
-                  onChange={() => setDraftValue(option.value)}
-                  className='h-4 w-4 rounded-full border-slate-300 text-primary accent-primary focus:ring-primary/30'
-                />
-                <span>{option.label}</span>
-              </label>
-            ))}
+            {options.map((option) => {
+              const isOptionDisabled = disabledValues?.includes(option.value) ?? false;
+              return (
+                <label
+                  key={option.value}
+                  className={clsx(
+                    'flex items-center gap-2',
+                    isOptionDisabled ? 'cursor-not-allowed opacity-40 text-slate-400' : 'text-slate-700'
+                  )}
+                >
+                  <input
+                    type='radio'
+                    name={filterKey}
+                    value={option.value}
+                    checked={draftValue === option.value}
+                    onChange={() => { if (!isOptionDisabled) setDraftValue(option.value); }}
+                    disabled={isOptionDisabled}
+                    className='h-4 w-4 rounded-full border-slate-300 text-primary accent-primary focus:ring-primary/30'
+                  />
+                  <span>{option.label}</span>
+                </label>
+              );
+            })}
           </div>
           <div className='mt-4 flex items-center justify-between text-sm'>
             {clearable ? (

--- a/apps/scheduling-app/app/providers/hooks/useProviders.ts
+++ b/apps/scheduling-app/app/providers/hooks/useProviders.ts
@@ -154,8 +154,12 @@ export function useProviders({
     // Map service string to Modality enum
     const modality = mapServiceToModality(service);
 
-    // Medicare patients must always see psychiatric clinicians
-    const isMedicare = insurance === INSURANCE_CARRIER_GROUPS.MEDICARE;
+    // Map user-selected insurance to carrier group for API filtering
+    const insuranceCarrierGroup = mapInsuranceToCarrierGroup(insurance);
+
+    // Medicare patients must always see psychiatric clinicians — check against
+    // the normalized carrier group so any future Medicare plan aliases also match
+    const isMedicare = insuranceCarrierGroup === INSURANCE_CARRIER_GROUPS.MEDICARE;
     const effectiveModality = isMedicare ? Modality.Psychiatric : modality;
 
     // Build location filter if state is valid
@@ -163,9 +167,6 @@ export function useProviders({
     if (state && isLocationState(state)) {
       location = { state: state as LocationState } as ProviderSearchFilters['location'];
     }
-
-    // Map user-selected insurance to carrier group for API filtering
-    const insuranceCarrierGroup = mapInsuranceToCarrierGroup(insurance);
 
     const nextFilters: ProviderSearchFilters = {
       ...DEFAULT_FILTERS,

--- a/apps/scheduling-app/app/providers/hooks/useProviders.ts
+++ b/apps/scheduling-app/app/providers/hooks/useProviders.ts
@@ -14,7 +14,7 @@ import {
   type OnboardingPreferences,
 } from '../_lib/onboarding';
 import { getProvidersAction } from '../actions';
-import { mapInsuranceToCarrierGroup } from '../../../lib/fields/registry';
+import { mapInsuranceToCarrierGroup, INSURANCE_CARRIER_GROUPS } from '../../../lib/fields/registry';
 
 const DEFAULT_FILTERS: ProviderSearchFilters = {
   age: '35',
@@ -85,6 +85,12 @@ const FILTER_MESSAGES: FilterMessageConfig[] = [
       "You've selected 'Not Sure' for a service type. We recommend booking with psychiatry first, so we are showing those clinicians below. If you would like to start with therapy, please filter to 'Therapy' instead. Our team will ultimately help you schedule with both services either way.",
     variant: 'info',
   },
+  {
+    condition: (filters) => filters.insurance === INSURANCE_CARRIER_GROUPS.MEDICARE,
+    message:
+      "Your first appointment must be with one of our psychiatry clinicians (shown below). They will establish your treatment plan. They may also refer you to one of our therapists if appropriate.",
+    variant: 'info',
+  },
 ];
 
 function getFilterMessage(
@@ -148,6 +154,10 @@ export function useProviders({
     // Map service string to Modality enum
     const modality = mapServiceToModality(service);
 
+    // Medicare patients must always see psychiatric clinicians
+    const isMedicare = insurance === INSURANCE_CARRIER_GROUPS.MEDICARE;
+    const effectiveModality = isMedicare ? Modality.Psychiatric : modality;
+
     // Build location filter if state is valid
     let location: ProviderSearchFilters['location'] | undefined;
     if (state && isLocationState(state)) {
@@ -159,7 +169,7 @@ export function useProviders({
 
     const nextFilters: ProviderSearchFilters = {
       ...DEFAULT_FILTERS,
-      ...(modality ? { therapeuticModality: modality } : {}),
+      ...(effectiveModality ? { therapeuticModality: effectiveModality } : {}),
       ...(location ? { location } : {}),
       ...(insuranceCarrierGroup ? { insurance: insuranceCarrierGroup } : {}),
     };


### PR DESCRIPTION
### **User description**
## Summary

Per the Medicare launch requirements, patients who select Medicare as their insurance must book with a psychiatry clinician first.

### Changes

**Auto-filter providers to Psychiatry for Medicare patients** (`useProviders.ts`)
- When `insurance === 'Medicare'`, the `therapeuticModality` filter is forced to `Modality.Psychiatric` regardless of the service type the patient selected during onboarding
- Added a new info banner on the providers page for Medicare patients: *"Your first appointment must be with one of our psychiatry clinicians (shown below). They will establish your treatment plan. They may also refer you to one of our therapists if appropriate."*

**Disable non-Psychiatric service filter options for Medicare patients** (`FilterPill.tsx`, `ProviderFilters.tsx`)
- Added a `disabledValues` prop to `FilterPill` to allow individual radio options within the dropdown to be greyed out and unclickable
- When Medicare is the active insurance, the Service filter (both desktop pill and mobile drawer) disables Therapy, Both, and Not Sure — only Psychiatry (Medication) remains selectable

**Fix husky pre-commit hook in VS Code / WSL** (`.husky/pre-commit`)
- `pnpm` was not in the PATH used by the VS Code git integration in WSL, causing pre-commit to fail with `pnpm: not found`. Added an explicit PATH export pointing to the nvm node bin directory.

## Test plan
- [x] Select Medicare in onboarding → providers page shows psychiatric clinicians + Medicare disclaimer banner
- [x] Select Medicare → open Service filter pill → Therapy/Both/Not Sure are greyed out and unclickable
- [x] Select a non-Medicare insurance → Service filter options are all enabled normally
- [x] Existing Both/Not Sure disclaimers still display correctly
- [x] Medicare overrides even if a previous service preference (e.g. Therapy) was saved in localStorage
- [x] Pre-commit hook runs successfully from VS Code git commit UI


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Restrict Medicare patients to psychiatry providers

- Disable non-psychiatry service filter choices

- Show Medicare-specific provider guidance banner

- Fix Husky `pnpm` path in WSL


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Medicare insurance selected"]
  B["Psychiatry modality enforced"]
  C["Non-psychiatry filter options disabled"]
  D["Medicare guidance banner shown"]
  E["WSL pre-commit PATH configured"]
  A -- "sets" --> B
  A -- "disables" --> C
  B -- "triggers" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProviderFilters.tsx</strong><dd><code>Disable invalid Medicare service filter choices</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/scheduling-app/app/providers/components/ProviderFilters.tsx

<ul><li>Import <code>INSURANCE_CARRIER_GROUPS</code> for Medicare checks<br> <li> Disable non-psychiatry desktop service options<br> <li> Disable non-psychiatry mobile select options</ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/119/files#diff-64bb5281c61b405a75e0e1b75031db0168c152b87eca554cb808e0221dc1f61a">+14/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FilterPill.tsx</strong><dd><code>Support disabled options in filter pill</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/scheduling-app/app/providers/components/filters/FilterPill.tsx

<ul><li>Add <code>disabledValues</code> prop for option-level disabling<br> <li> Grey out disabled radio options visually<br> <li> Prevent selecting disabled filter values</ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/119/files#diff-697d1937a89f979293b1108d3440a4124b3d286f26aa047a6b1f460e44886662">+26/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useProviders.ts</strong><dd><code>Enforce Medicare psychiatry-first provider results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/scheduling-app/app/providers/hooks/useProviders.ts

<ul><li>Import <code>INSURANCE_CARRIER_GROUPS</code> for Medicare logic<br> <li> Add Medicare-specific informational filter message<br> <li> Force Medicare service modality to <code>Modality.Psychiatric</code></ul>


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/119/files#diff-8bc450f651013797bfd7966248abdaa717fe4d97addb26285d2830dd1295d665">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pre-commit</strong><dd><code>Fix pre-commit PATH for WSL tooling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.husky/pre-commit

- Export NVM Node bin path
- Help `pnpm` resolve in VS Code WSL


</details>


  </td>
  <td><a href="https://github.com/awell-health/sol-scheduling/pull/119/files#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

